### PR TITLE
Code changes and organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ gradle.properties
 
 # ignore generated antlr files
 src/main/antlr/grammar/.antlr/
+
+# ignore IDE
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ plugins {
     
 
 task(crmlc, dependsOn: 'classes', type: JavaExec) {
-   mainClass = 'crml.compiler.CRMLC'
+   mainClass = 'crml.CRMLC'
    classpath = sourceSets.main.runtimeClasspath
 }
 
@@ -64,7 +64,7 @@ task printSourceSetInformation { // for debugging purposes
     }
 }
 application {
-    mainClass = 'crml.compiler.CRMLC'
+    mainClass = 'crml.CRMLC'
 }
 
 generateGrammarSource {
@@ -83,7 +83,7 @@ test {
 
 jar {
   manifest {
-   attributes 'Main-Class': 'crml.compiler.CRMLC'
+   attributes 'Main-Class': 'crml.CRMLC'
    attributes 'Multi-Release': 'true'
   }
 }

--- a/src/main/java/crml/CRMLC.java
+++ b/src/main/java/crml/CRMLC.java
@@ -5,17 +5,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
-import org.antlr.v4.runtime.tree.ParseTree;
-
-import grammar.crmlLexer;
-import grammar.crmlParser;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.platform.launcher.Launcher;
@@ -31,6 +23,8 @@ import com.beust.jcommander.JCommander;
 
 import crml.compiler.Value;
 import crml.compiler.crmlVisitorImpl;
+import crml.language.Parser;
+import crml.language.Parser.ParserResult;
 import crml.omc.CompileSettings;
 import crml.omc.ModelicaSimulationException;
 import crml.omc.OMCUtil;
@@ -163,19 +157,13 @@ public class CRMLC {
       String fullName = dir + java.io.File.separator + file;
       File in_file = new File(fullName);
     
-      CharStream code = CharStreams.fromFileName(in_file.getAbsolutePath());
-    
-      crmlLexer lexer = new crmlLexer(code);
-      CommonTokenStream tokens = new CommonTokenStream( lexer );
-      crmlParser parser = new crmlParser( tokens );
-      List<String> ruleNamesList = Arrays.asList(parser.getRuleNames());
-      ParseTree tree = parser.definition();
+      ParserResult parsed = Parser.parse(in_file);
       
-      if (tree == null)
+      if (parsed.ast() == null)
         logger.error("Unable to parse: " + file);
 
       if (printAST){
-            String prettyTree = Utilities.toPrettyTree(tree, ruleNamesList);
+            String prettyTree = Utilities.toPrettyTree(parsed.ast(), parsed.ruleNames());
             logger.trace("\nThe AST for the program: \n" + prettyTree);
           }
        
@@ -184,12 +172,12 @@ public class CRMLC {
      
 
       if (generateExternal)
-        visitor = new crmlVisitorImpl(parser, external_var, causal);
+        visitor = new crmlVisitorImpl(parsed.parser(), external_var, causal);
       else
-        visitor = new crmlVisitorImpl(parser, causal);
+        visitor = new crmlVisitorImpl(parsed.parser(), causal);
 
       try {
-        Value result = visitor.visit(tree);
+        Value result = visitor.visit(parsed.parser().definition());
   
         if (result != null) {  	
         
@@ -222,7 +210,7 @@ public class CRMLC {
         else {
           logger.error("Unable to translate: " + file + "\n");
           if (printAST){
-            String prettyTree = Utilities.toPrettyTree(tree, ruleNamesList);
+            String prettyTree = Utilities.toPrettyTree(parsed.ast(), parsed.ruleNames());
             logger.trace("\nThe AST for the program: \n" + prettyTree);
           }
           if(testMode)
@@ -234,7 +222,7 @@ public class CRMLC {
         
         logger.error("Translation error: "+ e, e);
         if (printAST){
-            String prettyTree = Utilities.toPrettyTree(tree, ruleNamesList);
+            String prettyTree = Utilities.toPrettyTree(parsed.ast(), parsed.ruleNames());
             logger.trace("\nThe AST for the program: \n" + prettyTree);
           }
         
@@ -243,7 +231,7 @@ public class CRMLC {
       catch(Exception e) {
         logger.error("Uncaught error: " + e, e);
         if (printAST){
-            String prettyTree = Utilities.toPrettyTree(tree, ruleNamesList);
+            String prettyTree = Utilities.toPrettyTree(parsed.ast(), parsed.ruleNames());
             logger.trace("\nThe AST for the program: \n" + prettyTree);
           }
         if (testMode) throw e;

--- a/src/main/java/crml/CRMLC.java
+++ b/src/main/java/crml/CRMLC.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -28,6 +28,14 @@ import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 import com.beust.jcommander.JCommander;
+
+import crml.compiler.Value;
+import crml.compiler.crmlVisitorImpl;
+import crml.omc.CompileSettings;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCUtil;
+import crml.omc.OMCmsg;
+import crml.test.TestListener;
 
 import org.apache.logging.log4j.LogManager;
 import org.junit.platform.engine.discovery.ClassNameFilter;

--- a/src/main/java/crml/CommandLineArgs.java
+++ b/src/main/java/crml/CommandLineArgs.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/crml/Utilities.java
+++ b/src/main/java/crml/Utilities.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml;
 
 import java.io.File;
 import java.util.List;

--- a/src/main/java/crml/language/ErrorListener.java
+++ b/src/main/java/crml/language/ErrorListener.java
@@ -1,0 +1,69 @@
+package crml.language;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.v4.runtime.Recognizer;
+
+import crml.language.ErrorListener.CRMLSyntaxError;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+
+public class ErrorListener extends BaseErrorListener {
+    private final List<CRMLSyntaxError> errors = new ArrayList<>();
+    
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer,
+                            Object offendingSymbol,
+                            int line,
+                            int charPositionInLine,
+                            String msg,
+                            RecognitionException e) {
+
+        errors.add(new CRMLSyntaxError(line, charPositionInLine, msg));
+    }
+
+    public CRMLSyntaxResults getErrors() {
+        return new CRMLSyntaxResults(errors);
+    }
+
+    public static class CRMLSyntaxError {
+        private final int line;
+        private final int charPosition;
+        private final String message;
+        public CRMLSyntaxError(int line, int charPosition, String message){
+            this.line = line;
+            this.charPosition = charPosition;
+            this.message = message;
+        }
+        public int line(){
+            return this.line;
+        }
+        public int charPosition() {
+            return this.charPosition;
+        }
+        public String message() {
+            return this.message;
+        }
+        
+        @Override
+        public String toString() {
+            return "ERROR (line " + line + ":" + charPosition + "): " + message;
+        }
+    }
+
+    public static class CRMLSyntaxResults {
+        private final List<CRMLSyntaxError> errors;
+        public CRMLSyntaxResults(List<CRMLSyntaxError> errors){
+            this.errors = errors;
+        }
+        public List<CRMLSyntaxError> errors() {
+            return this.errors;
+        }
+        public boolean hasErrors() {
+            return !errors.isEmpty();
+        }
+    }
+    
+}

--- a/src/main/java/crml/language/Parser.java
+++ b/src/main/java/crml/language/Parser.java
@@ -19,19 +19,19 @@ import grammar.crmlParser;
 import crml.language.ErrorListener.CRMLSyntaxResults;
 
 public class Parser {
-    public ParserResult parse(File model) throws IOException{
+    public static ParserResult parse(File model) throws IOException{
         return parse(CharStreams.fromPath(model.toPath()));
     }
     
-    public ParserResult parse(Path model) throws IOException{
+    public static ParserResult parse(Path model) throws IOException{
         return parse(CharStreams.fromPath(model));
     }
 
-    public ParserResult parse(String model){
+    public static ParserResult parse(String model){
         return parse(CharStreams.fromString(model));
     }
 
-    public ParserResult parse(CharStream model){
+    public static ParserResult parse(CharStream model){
         ErrorListener errors = new ErrorListener();
 
         crmlLexer lexer = new crmlLexer(model);

--- a/src/main/java/crml/language/Parser.java
+++ b/src/main/java/crml/language/Parser.java
@@ -1,0 +1,114 @@
+package crml.language;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.Tree;
+import org.antlr.v4.runtime.tree.Trees;
+import org.antlr.v4.runtime.misc.Utils;
+
+import grammar.crmlLexer;
+import grammar.crmlParser;
+import crml.language.ErrorListener.CRMLSyntaxResults;
+
+public class Parser {
+    public ParserResult parse(File model) throws IOException{
+        return parse(CharStreams.fromPath(model.toPath()));
+    }
+    
+    public ParserResult parse(Path model) throws IOException{
+        return parse(CharStreams.fromPath(model));
+    }
+
+    public ParserResult parse(String model){
+        return parse(CharStreams.fromString(model));
+    }
+
+    public ParserResult parse(CharStream model){
+        ErrorListener errors = new ErrorListener();
+
+        crmlLexer lexer = new crmlLexer(model);
+        lexer.removeErrorListeners(); // Remove default listener that prints the output
+        lexer.addErrorListener(errors);
+
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        crmlParser parser = new crmlParser(tokens);
+        parser.removeErrorListeners(); // Remove default listener that prints the output
+        parser.addErrorListener(errors);
+
+        List<String> ruleNames = Arrays.asList(parser.getRuleNames());
+        ParseTree tree = parser.definition();
+
+        return new ParserResult(parser, tree, ruleNames, errors.getErrors());
+    }
+
+    public static class ParserResult {
+        private static final String EOL = System.getProperty("line.separator");
+        private static final String INDENTS = "  ";
+        
+        private final crmlParser parser;
+        private final ParseTree ast;
+        private final List<String> ruleNames;
+        private final CRMLSyntaxResults syntax;
+        public ParserResult(crmlParser parser, ParseTree ast, List<String> ruleNames, CRMLSyntaxResults syntax){
+            this.parser = parser;
+            this.ast = ast;
+            this.ruleNames = ruleNames;
+            this.syntax = syntax;
+        }
+        public crmlParser parser(){
+            return this.parser;
+        }
+        public ParseTree ast(){
+            return this.ast;
+        }
+        public List<String> ruleNames(){
+            return this.ruleNames;
+        }
+        public CRMLSyntaxResults syntax(){
+            return this.syntax;
+        }
+
+
+        /**
+         * Pretty print out a whole tree. {@link #getNodeText} is used on the node payloads to get the text
+         * for the nodes. (Derived from Trees.toStringTree(....))
+         */
+        public String toPrettyTree() {
+            return process(0, ast, ruleNames).replaceAll("(?m)^\\s+$", "").replaceAll("\\r?\\n\\r?\\n", EOL);
+        }
+        
+        private static String process(int level, final Tree t, final List<String> ruleNames) {
+            if (t.getChildCount() == 0) return Utils.escapeWhitespace(Trees.getNodeText(t, ruleNames), false);
+            StringBuilder sb = new StringBuilder();
+            sb.append(lead(level));
+            level++;
+            String s = Utils.escapeWhitespace(Trees.getNodeText(t, ruleNames), false);
+            sb.append(s + ' ');
+            for (int i = 0; i < t.getChildCount(); i++) {
+                sb.append(process(level+1, t.getChild(i), ruleNames));
+            }
+            level--;
+            sb.append(lead(level));
+            return sb.toString();
+        }
+
+        private static String lead(int level) {
+         StringBuilder sb = new StringBuilder();
+         if (level > 0) {
+             sb.append(EOL);
+             for (int cnt = 0; cnt < level; cnt++) {
+                 sb.append(INDENTS);
+             }
+         }
+         return sb.toString();
+     }
+    }
+}

--- a/src/main/java/crml/omc/CompileSettings.java
+++ b/src/main/java/crml/omc/CompileSettings.java
@@ -1,7 +1,9 @@
-package crml.compiler;
+package crml.omc;
 
 import java.io.File;
 import java.net.URL;
+
+import crml.Utilities;
 
 public class CompileSettings {
     

--- a/src/main/java/crml/omc/ModelicaSimulationException.java
+++ b/src/main/java/crml/omc/ModelicaSimulationException.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml.omc;
 
 public class ModelicaSimulationException extends Throwable {
 

--- a/src/main/java/crml/omc/OMCUtil.java
+++ b/src/main/java/crml/omc/OMCUtil.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml.omc;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.TimeUnit;
+
+import crml.Utilities;
 
 import static j2html.TagCreator.*;
 

--- a/src/main/java/crml/omc/OMCmsg.java
+++ b/src/main/java/crml/omc/OMCmsg.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml.omc;
 
 public class OMCmsg {
         public String files;

--- a/src/main/java/crml/test/TestListener.java
+++ b/src/main/java/crml/test/TestListener.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml.test;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;

--- a/src/main/java/crml/test/TestMonitor.java
+++ b/src/main/java/crml/test/TestMonitor.java
@@ -1,4 +1,4 @@
-package crml.compiler;
+package crml.test;
 
 import java.lang.reflect.Field;
 

--- a/src/test/java/ctests/ETLTests.java
+++ b/src/test/java/ctests/ETLTests.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import crml.compiler.ModelicaSimulationException;
-import crml.compiler.OMCmsg;
-import crml.compiler.Utilities;
-import crml.compiler.OMCUtil.CompileStage;
+import crml.Utilities;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCmsg;
+import crml.omc.OMCUtil.CompileStage;
 
 import org.junit.jupiter.params.ParameterizedTest;
 

--- a/src/test/java/ctests/FORMLTests.java
+++ b/src/test/java/ctests/FORMLTests.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import crml.compiler.ModelicaSimulationException;
-import crml.compiler.OMCmsg;
-import crml.compiler.Utilities;
-import crml.compiler.OMCUtil.CompileStage;
+import crml.Utilities;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCmsg;
+import crml.omc.OMCUtil.CompileStage;
 
 import org.junit.jupiter.params.ParameterizedTest;
 

--- a/src/test/java/ctests/ParameterizedSuite.java
+++ b/src/test/java/ctests/ParameterizedSuite.java
@@ -10,8 +10,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import crml.compiler.CompileSettings;
-import crml.compiler.TestListener;
+import crml.omc.CompileSettings;
+import crml.test.TestListener;
 
 @ExtendWith(TestListener.class) // a hook for catching succesful test results in the test report
 public class ParameterizedSuite {

--- a/src/test/java/ctests/SpecificationTests.java
+++ b/src/test/java/ctests/SpecificationTests.java
@@ -7,9 +7,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-
-import crml.compiler.ModelicaSimulationException;
-import crml.compiler.OMCUtil.CompileStage;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCUtil.CompileStage;
 
 /**
  * 

--- a/src/test/java/ctests/UseCaseTests.java
+++ b/src/test/java/ctests/UseCaseTests.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import crml.compiler.CompileSettings;
-import crml.compiler.ModelicaSimulationException;
-import crml.compiler.OMCUtil.CompileStage;
+import crml.omc.CompileSettings;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCUtil.CompileStage;
 
 
 public class UseCaseTests {

--- a/src/test/java/ctests/Util.java
+++ b/src/test/java/ctests/Util.java
@@ -3,12 +3,12 @@ package ctests;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 
-import crml.compiler.CompileSettings;
-import crml.compiler.ModelicaSimulationException;
-import crml.compiler.OMCUtil;
-import crml.compiler.OMCmsg;
-import crml.compiler.Utilities;
-import crml.compiler.OMCUtil.CompileStage;
+import crml.Utilities;
+import crml.omc.CompileSettings;
+import crml.omc.ModelicaSimulationException;
+import crml.omc.OMCUtil;
+import crml.omc.OMCmsg;
+import crml.omc.OMCUtil.CompileStage;
 
 import java.io.File;
 
@@ -35,7 +35,7 @@ public class Util {
 		// try compiling crml to modelica
 		try {
     		
-			crml.compiler.CRMLC.parse_file(cs.testFolderIn, fileName, out_dir, 
+			crml.CRMLC.parse_file(cs.testFolderIn, fileName, out_dir, 
 				true, false, true, stripped_file_name, false);
 			
     	} catch (Exception e) {

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,1 +1,1 @@
-crml.compiler.TestListener
+crml.test.TestListener


### PR DESCRIPTION
@lenaRB 
As discussed during our last meeting, I starter cleaning up some of the changes I made.

So here is the first batch of changes (preserving java 1.8)
* Code is split into 4+1 packages 
  * `crml.compiler`: Code related to translating CRML to Modelica
  * `crml.langauge`: Code related to parsing CRML
  * `crml.omc`: Code related to running OpenModelica
  * `crml.test`: Test related stuff (I hope to eventually move it to `/src/test/java`)
  * `crml`: Application code (main)
* Parsing CRML models should be done with `crml.language.Parser`. It has static functions to parse input from `File`, `Path`, `String` and `CharStream`. Latter 2 expect the textual model, not a textual path. Return type is a `ParserResult` that wraps the related artifacts. (It was originally a `record`, but that is not available in Java 1.8.)

I have a few more question for the continuation:
* How strict is the requirement to use Groovy for Gradle, instead of Kotlin? (I find Kotlin a bit better and I already moved my version to it.)
* Is it ok to separate the project to submodules for `language` and `compiler`?
* Can I make the changes to move the test from `main` to `test`? I plan to make the calls for the specific tests to make if that is ok.
* I'm thinking about how I can address the missing language features from later Java version.
  *  Is there a specific IDE that we use? Some tools only work with IntelliJ nicely and otherwise it just makes a mess.
  *  Would it be a problem if parts of the code were in Kotlin? (It has most of the convenient features and should be easy to make it target the Java 1.8 JVM.)