### PR TITLE
[Fix] Enforce Java 1.8 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ jar {
 
 apply plugin: 'java'
 compileJava {
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+compileJava {
+    // See naming convention on why 8 is the same as 1.8
+    // https://softwareengineering.stackexchange.com/questions/175075/why-is-java-version-1-x-referred-to-as-java-x
+    options.release = 8
+}
 }


### PR DESCRIPTION
Current version only enforces that the source code syntax and target byte code is compliant with Java 8, but it does not enforce that the used APIs are also compatible.

Example
```java
Optional<String> foo = Optional.of(null);
foo.isEmpty(); // Introduced in Java 11
```

This code compiles, but results in a runtime failure if the Java  JRE is <11.

The patch prevents the compilation of code, where newer API is used.